### PR TITLE
Prepend \ before apostrophe

### DIFF
--- a/qBittorrentClient/res/values/strings.xml
+++ b/qBittorrentClient/res/values/strings.xml
@@ -101,7 +101,7 @@
     <string name="settings_qbittorrent_hostname_summary">Hostname or IP</string>
     <string name="settings_qbittorrent_hostname_dialog_title">Hostname or IP?</string>
     <string name="settings_qbittorrent_subfolder_title">Subfolder</string>
-    <string name="settings_qbittorrent_subfolder_dialog_title">Subfolder? If you're in doubt, leave it blank!</string>
+    <string name="settings_qbittorrent_subfolder_dialog_title">Subfolder? If you\'re in doubt, leave it blank!</string>
     <string name="settings_qbittorrent_https_title">Enable https</string>
     <string name="settings_qbittorrent_https_summary">Connect using https</string>
     <string name="settings_qbittorrent_port_title">Connection Port</string>


### PR DESCRIPTION
ant build gives this error:
  res/values/strings.xml:104: error: Apostrophe not preceded by \ (in Subfolder? If you're in doubt, leave it blank!)
