### PR TITLE
CSRF fix.

### DIFF
--- a/app/src/main/java/com/lgallardo/qbittorrentclient/JSONParser.java
+++ b/app/src/main/java/com/lgallardo/qbittorrentclient/JSONParser.java
@@ -171,8 +171,8 @@ public class JSONParser {
             }
 
             // Fix for CSRF in API requests
-            httpget.setHeader("Referer", this.protocol + "://" + this.hostname + ":" + this.port);
-            httpget.setHeader("Host", this.protocol + "://" + this.hostname + ":" + this.port);
+            httpget.setHeader("Referer", this.protocol + "://" + this.hostname + ":" + this.port + "/" + this.subfolder);
+            httpget.setHeader("Host", this.hostname);
 
 //            Header h[] = httpget.getAllHeaders();
 //            for(int i=0; i< h.length; i++){
@@ -289,8 +289,8 @@ public class JSONParser {
             }
 
             // Fix for CSRF in API requests
-            httpget.setHeader("Referer", this.protocol + "://" + this.hostname + ":" + this.port);
-            httpget.setHeader("Host", this.protocol + "://" + this.hostname + ":" + this.port);
+            httpget.setHeader("Referer", this.protocol + "://" + this.hostname + ":" + this.port + "/" + this.subfolder);
+            httpget.setHeader("Host", this.hostname);
 
 //            Header h[] = httpget.getAllHeaders();
 //            for(int i=0; i< h.length; i++){
@@ -734,8 +734,8 @@ public class JSONParser {
             }
 
             // Fix for CSRF in API requests
-            httpget.setHeader("Referer", this.protocol + "://" + this.hostname + ":" + this.port);
-            httpget.setHeader("Host", this.protocol + "://" + this.hostname + ":" + this.port);
+            httpget.setHeader("Referer", this.protocol + "://" + this.hostname + ":" + this.port + "/" + this.subfolder);
+            httpget.setHeader("Host", this.hostname);
 
 //            Header h[] = httpget.getAllHeaders();
 //            for(int i=0; i< h.length; i++){
@@ -962,8 +962,8 @@ public class JSONParser {
             nvps.add(new BasicNameValuePair("password", this.password));
 
             // Fix for CSRF in API requests
-            httpget.setHeader("Referer", this.protocol + "://" + this.hostname + ":" + this.port);
-            httpget.setHeader("Host", this.protocol + "://" + this.hostname + ":" + this.port);
+            httpget.setHeader("Referer", this.protocol + "://" + this.hostname + ":" + this.port + "/" + this.subfolder);
+            httpget.setHeader("Host", this.hostname);
 
 //            Header h[] = httpget.getAllHeaders();
 //            for(int i=0; i< h.length; i++){
@@ -1071,8 +1071,8 @@ public class JSONParser {
             HttpGet httpget = new HttpGet(url);
 
             // Fix for CSRF in API requests
-            httpget.setHeader("Referer", this.protocol + "://" + this.hostname + ":" + this.port);
-            httpget.setHeader("Host", this.protocol + "://" + this.hostname + ":" + this.port);
+            httpget.setHeader("Referer", this.protocol + "://" + this.hostname + ":" + this.port + "/" + this.subfolder);
+            httpget.setHeader("Host", this.hostname);
 
 //            Header h[] = httpget.getAllHeaders();
 //            for(int i=0; i< h.length; i++){
@@ -1175,8 +1175,8 @@ public class JSONParser {
             HttpGet httpget = new HttpGet(url);
 
             // Fix for CSRF in API requests
-            httpget.setHeader("Referer", this.protocol + "://" + this.hostname + ":" + this.port);
-            httpget.setHeader("Host", this.protocol + "://" + this.hostname + ":" + this.port);
+            httpget.setHeader("Referer", this.protocol + "://" + this.hostname + ":" + this.port + "/" + this.subfolder);
+            httpget.setHeader("Host", this.hostname);
 
 //            Header h[] = httpget.getAllHeaders();
 //            for(int i=0; i< h.length; i++){


### PR DESCRIPTION
With these CSRF settings I can use the controller with qbittorrent-nox v3.3.1. If you try to login with a browser it will use the same HTTP header convention as in this pull request.